### PR TITLE
Patch to add Literate CoffeeScript support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,22 @@
-var Filter = require('broccoli-filter')
-var coffeeScript = require('coffee-script')
+/* jshint node: true */
 
-module.exports = CoffeeScriptFilter
-CoffeeScriptFilter.prototype = Object.create(Filter.prototype)
-CoffeeScriptFilter.prototype.constructor = CoffeeScriptFilter
+var Filter = require('broccoli-filter');
+var coffeeScript = require('coffee-script');
+
+module.exports = CoffeeScriptFilter;
+CoffeeScriptFilter.prototype = Object.create(Filter.prototype);
+CoffeeScriptFilter.prototype.constructor = CoffeeScriptFilter;
 function CoffeeScriptFilter (inputTree, options) {
-  if (!(this instanceof CoffeeScriptFilter)) return new CoffeeScriptFilter(inputTree, options)
-  Filter.call(this, inputTree, options)
-  options = options || {}
-  this.bare = options.bare
+  if (!(this instanceof CoffeeScriptFilter)) {
+    return new CoffeeScriptFilter(inputTree, options);
+  }
+  Filter.call(this, inputTree, options);
+  options = options || {};
+  this.bare = options.bare;
 }
 
-CoffeeScriptFilter.prototype.extensions = ['coffee','litcoffee','coffee.md']
-CoffeeScriptFilter.prototype.targetExtension = 'js'
+CoffeeScriptFilter.prototype.extensions = ['coffee','litcoffee','coffee.md'];
+CoffeeScriptFilter.prototype.targetExtension = 'js';
 
 CoffeeScriptFilter.prototype.processString = function (string, srcFile) {
   var coffeeScriptOptions = {
@@ -21,10 +25,10 @@ CoffeeScriptFilter.prototype.processString = function (string, srcFile) {
   };
 
   try {
-    return coffeeScript.compile(string, coffeeScriptOptions)
+    return coffeeScript.compile(string, coffeeScriptOptions);
   } catch (err) {
-    err.line = err.location && err.location.first_line
-    err.column = err.location && err.location.first_column
-    throw err
+    err.line = err.location && err.location.first_line;
+    err.column = err.location && err.location.first_column;
+    throw err;
   }
-}
+};


### PR DESCRIPTION
`.coffee.md` and `.litcoffee` files are included in preprocessing and will be treated by the CoffeeScript processor as literate; i.e. anything not indented -- from what I can tell by at least 6 spaces -- will be treated as a comment, and anything indented appropriately will be considered code.

I don't have a very comprehensive test setup but it seems to work fine now with both regular and literate CoffeeScript files (run through Ember-CLI).
