### PR TITLE
Update broccoli-filter to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   ],
   "dependencies": {
     "coffee-script": "~1.7.1",
-    "broccoli-filter": "^0.1.6"
+    "broccoli-filter": "^0.1.7"
   }
 }


### PR DESCRIPTION
Without this, we get older versions of broccoli-kitchen-sink-helpers
that do not properly handle symlinks.

Same issue as described in https://github.com/broccolijs/broccoli-filter/pull/16.

@joliss - Once merged, can you release?
