### PR TITLE
fix CoffeeScript.register() error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var coffeeScript = require('coffee-script')
 var stringify = require('json-stable-stringify')
 
 module.exports = CoffeeScriptFilter
+coffeeScript.register()
 CoffeeScriptFilter.prototype = Object.create(Filter.prototype)
 CoffeeScriptFilter.prototype.constructor = CoffeeScriptFilter
 function CoffeeScriptFilter (inputTree, options) {


### PR DESCRIPTION
I was giving CoffeeScript a whirl in ember.js, and ran into the all-too-common "Use CoffeeScript.register() or require the coffee-script/register module to require [...]" error.

Versions involved:

node 4.2.6
npm 3.10.8
ember-cli 2.9.1
ember-cli-coffeescript 1.15.0
broccoli-coffee 0.7.0

I suppose the `.register` could be pushed up the chain to `ember-cli-coffeescript`. Frankly I'm surprised that `broccoli-coffee` has gone through so many `coffee-script` version bumps without addressing this error, it makes me think I'm missing something in my setup at some other level...?