### PR TITLE
Allow passing custom coffeescript library

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,18 @@ function wrapper:
 
 ```js
 new BroccoliCoffee(node, {
-  bare: true
+  bare: true,
+  coffeescript: require('coffee-script')
+})
+```
+
+#### coffeescript
+
+BroccoliCoffee uses coffeescript 2.x. If your project depends on coffeescript 1.x, pass it in `coffeescript`
+
+```js
+new BroccoliCoffee(node, {
+  coffeescript: require('coffee-script')
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function CoffeeScriptFilter (inputTree, options) {
   if (!(this instanceof CoffeeScriptFilter)) return new CoffeeScriptFilter(inputTree, options)
   Filter.call(this, inputTree, options)
   options = options || {}
+  if (options.coffeescript) coffeeScript = options.coffeescript;
   this.bare = options.bare;
   this.options = options;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-coffee",
-  "version": "0.8.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR adds a `coffeescript` option that allows a custom coffeescript version to be used. Projects that depend on coffeescript 1.x (such as ours) might benefit from this option.